### PR TITLE
First draft for styling dataset, flow, run, and task details.

### DIFF
--- a/server/src/client/app/src/pages/search/Dataset.js
+++ b/server/src/client/app/src/pages/search/Dataset.js
@@ -1,7 +1,8 @@
 import React from "react";
-import { SizeLimiter } from "./sizeLimiter.js";
+import { SizeLimiter, CollapsibleDataTable } from "./sizeLimiter.js";
 import { FeatureDetail } from "./ItemDetail.js";
 import { QualityDetail } from "./ItemDetail.js";
+
 import ReactMarkdown from "react-markdown";
 import {
   Chip,
@@ -12,57 +13,45 @@ import {
   Grid
 } from "@material-ui/core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {MyDataTable} from "./sizeLimiter";
 
 export class DatasetItem extends React.Component {
+  constructor() {
+    super();
+    this.defaultFeatureListSizeLimit = 7;
+    this.featureSizeLimit = this.defaultFeatureListSizeLimit;
+  }
   render() {
+    let featureTableColumns = [ "", "Feature Name", "Type", "Distinct/Missing Values" ];
+    let qualityTableColumns = [ "", "Quality Name", "Value"];
+
     return (
       <React.Fragment>
         <Grid container spacing={6}>
           <Grid item xs={12}>
-            <h1 className={"sectionTitle"}>
-              <span className={"fa fa-database"} />
-              {this.props.object.name}
-            </h1>
-            uploaded by{" "}
-            <Chip
-              size="small"
-              variant="outlined"
-              color="primary"
-              avatar={<Avatar>{this.props.object.uploader.charAt(0)}</Avatar>}
-              label={this.props.object.uploader}
-            />{" "}
-            at <FontAwesomeIcon icon="clock" /> {this.props.object.date}
-            <div className="dataStats">
-              <span>
-                <FontAwesomeIcon icon="table" /> {this.props.object.format}
-              </span>
-              <span>
-                <FontAwesomeIcon icon="closed-captioning" />
-                {this.props.object.licence}
-              </span>
-              <span>
-                <FontAwesomeIcon icon="heart" />
-                {this.props.object.nr_of_likes} likes
-              </span>
-              <span>
-                <FontAwesomeIcon icon="cloud" />
-                {this.props.object.nr_of_downloads} downloads
-              </span>
-              <span>
-                <FontAwesomeIcon icon="exclamation-triangle" />
-                {this.props.object.nr_of_issues} issues
-              </span>
-              <span>
-                <FontAwesomeIcon icon="thumbs-down" />
-                {this.props.object.nr_of_downvotes} downvotes
-              </span>
-              <br />
-              <span>
-                <FontAwesomeIcon icon="tags" />
-                {this.props.tags}
-              </span>
-            </div>
+            <Grid container className="dataStats">
+              <Grid item md={2} ><FontAwesomeIcon icon="table" />&nbsp;{this.props.object.format}</Grid>
+              <Grid item md={2}><FontAwesomeIcon icon="closed-captioning" />&nbsp;{this.props.object.licence}</Grid>
+              <Grid item md={2}><FontAwesomeIcon icon="heart" />&nbsp;{this.props.object.nr_of_likes} likes</Grid>
+              <Grid item md={2}><FontAwesomeIcon icon="cloud" />&nbsp;{this.props.object.nr_of_downloads} downloads</Grid>
+              <Grid item md={2}><FontAwesomeIcon icon="exclamation-triangle" />&nbsp;{this.props.object.nr_of_issues} issues</Grid>
+              <Grid item md={2}><FontAwesomeIcon icon="thumbs-down" />&nbsp;{this.props.object.nr_of_downvotes} downvotes</Grid>
+            </Grid>
+
+            <Grid container style={{"padding": "25px 0"}}>
+              <Grid item md={12}>
+                <Typography variant="h1" style={{"margin-bottom": "15px"}}><FontAwesomeIcon icon="database" />&nbsp;&nbsp;&nbsp;{this.props.object.name}</Typography>
+              </Grid>
+              <Grid item md={12}>uploaded <FontAwesomeIcon icon="clock" />{" "}{this.props.object.date} by{" "}
+                <Chip size="small" variant="outlined" color="primary" avatar={<Avatar>{this.props.object.uploader.charAt(0)}</Avatar>} label={this.props.object.uploader}/>
+              </Grid>
+            </Grid>
+
+            <Grid container>
+              <Grid item md={12}><FontAwesomeIcon icon="tags" />{" "}{this.props.tags}</Grid>
+            </Grid>
           </Grid>
+
           <Grid item xs={12}>
             <Card>
               <CardContent>
@@ -78,42 +67,14 @@ export class DatasetItem extends React.Component {
           <Grid item xs={12}>
             <Card>
               <CardContent>
-                <Typography variant="h4" mb={6}>
-                  Features
-                </Typography>
-                <div className={"subtitle"}>
-                  {this.props.object.features.length} total features
-                </div>
-                <SizeLimiter maxLength={7}>
-                  {this.props.object.features.map(m => (
-                    <FeatureDetail
-                      key={"fd_" + m.name}
-                      item={m}
-                      type={m.type}
-                    ></FeatureDetail>
-                  ))}
-                </SizeLimiter>
+                <CollapsibleDataTable title={"Features"} subtitle={this.props.object.features.length + " features in total"} columns={featureTableColumns} data={this.props.object.features} rowrenderer={(m) => (<FeatureDetail key={"fd_" + m.name} item={m} type={m.type}></FeatureDetail>)} maxLength={7} />
               </CardContent>
             </Card>
           </Grid>
           <Grid item xs={12}>
             <Card>
               <CardContent>
-                <Typography variant="h4" mb={6}>
-                  Qualities
-                </Typography>
-                <div className={"subtitle"}>
-                  {Object.keys(this.props.object.qualities).length} total
-                  qualities
-                </div>
-                <SizeLimiter maxLength={7}>
-                  {Object.keys(this.props.object.qualities).map(m => (
-                    <QualityDetail
-                      key={"q_" + m}
-                      item={{ name: m, value: this.props.object.qualities[m] }}
-                    />
-                  ))}
-                </SizeLimiter>
+                <CollapsibleDataTable title={"Qualities"} subtitle={Object.keys(this.props.object.qualities).length + " qualities in total"} data={Object.keys(this.props.object.qualities)} rowrenderer={(m) => (<QualityDetail key={"q_" + m} item={{ name: m, value: this.props.object.qualities[m] }} />)} columns={qualityTableColumns} maxLength={7}/>
               </CardContent>
             </Card>
           </Grid>

--- a/server/src/client/app/src/pages/search/Dataset.js
+++ b/server/src/client/app/src/pages/search/Dataset.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { CollapsibleDataTable } from "./sizeLimiter.js";
-import { FeatureDetail } from "./ItemDetail.js";
-import { QualityDetail } from "./ItemDetail.js";
+import { FeatureDetail, QualityDetail } from "./ItemDetail.js";
 
 import ReactMarkdown from "react-markdown";
 import {
@@ -34,14 +33,16 @@ export class DatasetItem extends React.Component {
                 <Typography variant="h1" style={{"margin-bottom": "15px"}}><FontAwesomeIcon icon="database" />&nbsp;&nbsp;&nbsp;{this.props.object.name}</Typography>
               </Grid>
               <Grid item md={12}>
+                <MetaTag type={"status"} value={this.props.object.status} />
                 <MetaTag type={"format"} value={this.props.object.format} />
                 <MetaTag type={"licence"} value={this.props.object.licence} />
+                <MetaTag type={"uploaded"} date={this.props.object.date} uploader={this.props.object.uploader}/><br />
                 uploaded <FontAwesomeIcon icon="clock" />{" "}{this.props.object.date} by{" "}
                 <Chip size="small" variant="outlined" color="primary" avatar={<Avatar>{this.props.object.uploader.charAt(0)}</Avatar>} label={this.props.object.uploader}/><br />
                 <MetaTag type={"likes"} value={this.props.object.nr_of_likes} />
                 <MetaTag type={"issues"} value={this.props.object.nr_of_issues} />
                 <MetaTag type={"downvotes"} value={this.props.object.nr_of_downvotes} />
-                <MetaTag type={"downloads"} value={this.props.object.nr_of_downloads+ " downloads"} />
+                <MetaTag type={"downloads"} value={this.props.object.nr_of_downloads} />
               </Grid>
             </Grid>
 
@@ -69,6 +70,7 @@ export class DatasetItem extends React.Component {
               </CardContent>
             </Card>
           </Grid>
+
           <Grid item xs={12}>
             <Card>
               <CardContent>
@@ -76,6 +78,7 @@ export class DatasetItem extends React.Component {
               </CardContent>
             </Card>
           </Grid>
+
           <Grid item xs={12}>
             <Card>
               <CardContent>
@@ -88,6 +91,7 @@ export class DatasetItem extends React.Component {
               </CardContent>
             </Card>
           </Grid>
+
         </Grid>
       </React.Fragment>
     );

--- a/server/src/client/app/src/pages/search/Dataset.js
+++ b/server/src/client/app/src/pages/search/Dataset.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { SizeLimiter, CollapsibleDataTable } from "./sizeLimiter.js";
+import { CollapsibleDataTable } from "./sizeLimiter.js";
 import { FeatureDetail } from "./ItemDetail.js";
 import { QualityDetail } from "./ItemDetail.js";
 
@@ -13,7 +13,7 @@ import {
   Grid
 } from "@material-ui/core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {MyDataTable} from "./sizeLimiter";
+import {MetaTag} from "./MetaItems"
 
 export class DatasetItem extends React.Component {
   constructor() {
@@ -29,21 +29,19 @@ export class DatasetItem extends React.Component {
       <React.Fragment>
         <Grid container spacing={6}>
           <Grid item xs={12}>
-            <Grid container className="dataStats">
-              <Grid item md={2} ><FontAwesomeIcon icon="table" />&nbsp;{this.props.object.format}</Grid>
-              <Grid item md={2}><FontAwesomeIcon icon="closed-captioning" />&nbsp;{this.props.object.licence}</Grid>
-              <Grid item md={2}><FontAwesomeIcon icon="heart" />&nbsp;{this.props.object.nr_of_likes} likes</Grid>
-              <Grid item md={2}><FontAwesomeIcon icon="cloud" />&nbsp;{this.props.object.nr_of_downloads} downloads</Grid>
-              <Grid item md={2}><FontAwesomeIcon icon="exclamation-triangle" />&nbsp;{this.props.object.nr_of_issues} issues</Grid>
-              <Grid item md={2}><FontAwesomeIcon icon="thumbs-down" />&nbsp;{this.props.object.nr_of_downvotes} downvotes</Grid>
-            </Grid>
-
             <Grid container style={{"padding": "25px 0"}}>
               <Grid item md={12}>
                 <Typography variant="h1" style={{"margin-bottom": "15px"}}><FontAwesomeIcon icon="database" />&nbsp;&nbsp;&nbsp;{this.props.object.name}</Typography>
               </Grid>
-              <Grid item md={12}>uploaded <FontAwesomeIcon icon="clock" />{" "}{this.props.object.date} by{" "}
-                <Chip size="small" variant="outlined" color="primary" avatar={<Avatar>{this.props.object.uploader.charAt(0)}</Avatar>} label={this.props.object.uploader}/>
+              <Grid item md={12}>
+                <MetaTag type={"format"} value={this.props.object.format} />
+                <MetaTag type={"licence"} value={this.props.object.licence} />
+                uploaded <FontAwesomeIcon icon="clock" />{" "}{this.props.object.date} by{" "}
+                <Chip size="small" variant="outlined" color="primary" avatar={<Avatar>{this.props.object.uploader.charAt(0)}</Avatar>} label={this.props.object.uploader}/><br />
+                <MetaTag type={"likes"} value={this.props.object.nr_of_likes} />
+                <MetaTag type={"issues"} value={this.props.object.nr_of_issues} />
+                <MetaTag type={"downvotes"} value={this.props.object.nr_of_downvotes} />
+                <MetaTag type={"downloads"} value={this.props.object.nr_of_downloads+ " downloads"} />
               </Grid>
             </Grid>
 
@@ -67,14 +65,14 @@ export class DatasetItem extends React.Component {
           <Grid item xs={12}>
             <Card>
               <CardContent>
-                <CollapsibleDataTable title={"Features"} subtitle={this.props.object.features.length + " features in total"} columns={featureTableColumns} data={this.props.object.features} rowrenderer={(m) => (<FeatureDetail key={"fd_" + m.name} item={m} type={m.type}></FeatureDetail>)} maxLength={7} />
+                <CollapsibleDataTable title={this.props.object.features.length + " Features"} columns={featureTableColumns} data={this.props.object.features} rowrenderer={(m) => (<FeatureDetail key={"fd_" + m.name} item={m} type={m.type}></FeatureDetail>)} maxLength={7} />
               </CardContent>
             </Card>
           </Grid>
           <Grid item xs={12}>
             <Card>
               <CardContent>
-                <CollapsibleDataTable title={"Qualities"} subtitle={Object.keys(this.props.object.qualities).length + " qualities in total"} data={Object.keys(this.props.object.qualities)} rowrenderer={(m) => (<QualityDetail key={"q_" + m} item={{ name: m, value: this.props.object.qualities[m] }} />)} columns={qualityTableColumns} maxLength={7}/>
+                <CollapsibleDataTable title={Object.keys(this.props.object.qualities).length + " Qualities"} data={Object.keys(this.props.object.qualities)} rowrenderer={(m) => (<QualityDetail key={"q_" + m} item={{ name: m, value: this.props.object.qualities[m] }} />)} columns={qualityTableColumns} maxLength={7}/>
               </CardContent>
             </Card>
           </Grid>

--- a/server/src/client/app/src/pages/search/Flow.js
+++ b/server/src/client/app/src/pages/search/Flow.js
@@ -1,9 +1,16 @@
 import React from "react";
-import { SizeLimiter } from "./sizeLimiter.js";
-import { ParameterDetail } from "./ItemDetail.js";
+import { StringLimiter, CollapsibleDataTable } from "./sizeLimiter.js";
+import { LightTooltip, ParameterDetail, DependencyDetail } from "./ItemDetail.js";
 import ReactMarkdown from "react-markdown";
 import styled from "styled-components";
-import { Typography } from "@material-ui/core";
+import {
+  Card,
+  CardContent,
+  Typography,
+  Grid
+} from "@material-ui/core";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {MetaTag} from "./MetaItems"
 
 const FlowName = styled(Typography)`
   width: 100vw;
@@ -15,74 +22,72 @@ const FlowName = styled(Typography)`
 
 export class FlowItem extends React.Component {
   render() {
+    let dependenciesMap = this.props.object.dependencies.split(", ").map(x => x.split("_"));
+    let parameterCols = ["Name", "Description", "Type", "Default Value"];
+
     return (
       <React.Fragment>
-        <FlowName variant="h1">
-          <span className={"fa fa-cogs"} />
-          {this.props.object.name}
-        </FlowName>
-        <div className="dataStats">
-          <div className="subtitle"></div>
-          <span>
-            <span className="fa fa-eye-slash" />
-            Visibility:{this.props.object.visibility}
-          </span>
-          <span>
-            <span className="fa fa-cloud-upload" />
-            uploaded {this.props.object.date} by {this.props.object.uploader}
-          </span>
-          <span>
-            <span className="fa fa-cloud-upload" />
-            {this.props.object.dependencies}
-          </span>
+        <Grid container spacing={6}>
+          <Grid item xs={12}>
+            <Grid container style={{"padding": "25px 0"}}>
+              <Grid item md={12}>
+                <LightTooltip title={this.props.object.name}>
+                <Typography variant={"h1"} style={{"marginBottom": "15px", "wordWrap": "break-word"}}><FontAwesomeIcon icon={"cogs"} />&nbsp;&nbsp;&nbsp;<StringLimiter maxLength={65} value={this.props.object.name} /></Typography>
+                </LightTooltip>
+              </Grid>
+              <Grid item md={12}>
+                <MetaTag type={"status"} value={this.props.object.visibility} />
+                <MetaTag type={"uploaded"} date={this.props.object.date} uploader={this.props.object.uploader} /><br />
 
-          <span>
-            <span className="fa fa-star" />
-            {this.props.object.runs} runs
-          </span>
-          <span>
-            <span className="fa fa-heart" />
-            {this.props.object.nr_of_likes} likes
-          </span>
-          <span>
-            <span className="fa fa-cloud" />
-            downloaded by {this.props.object.nr_of_downlaods}{" "}
-          </span>
-          <span>
-            <span className="fa fa-exclamation-triangle" />
-            {this.props.object.nr_of_issues} issues
-          </span>
-          <span>
-            <span className="fa fa-thumbs-down" />
-            {this.props.object.nr_of_downvotes} downvotes
-          </span>
-          <span>
-            <span className="fa fa-thumbs-down" />
-            {this.props.object.total_downloads}total downloads
-          </span>
-          <span>
-            <span className="fa fa-tags" />
-            {this.props.tags}
-          </span>
-        </div>
-        <div className="contentSection">
-          <ReactMarkdown source={this.props.object.description} />
-        </div>
-        <h1>Parameters</h1>
-        <SizeLimiter maxLength={7}>
-          {this.props.object.parameters
-            ? this.props.object.parameters.map(m => (
-                <ParameterDetail
-                  key={"fd_" + m.name}
-                  item={m}
-                ></ParameterDetail>
-              ))
-            : ""}
-        </SizeLimiter>
-        <h1>{this.props.object.runs} Runs</h1>
-        <div className={"subtitle"}>
-          Run visualization not currently supported
-        </div>
+                <MetaTag type={"likes"} value={this.props.object.nr_of_likes} />
+                <MetaTag type={"issues"} value={this.props.object.nr_of_issues} />
+                <MetaTag type={"downvotes"} value={this.props.object.nr_of_downvotes} />
+                <MetaTag type={"downloads"} value={this.props.object.nr_of_downloads} />
+                <MetaTag type={"runs"} value={this.props.object.runs} />
+              </Grid>
+
+            </Grid>
+
+            <Grid container>
+              <Grid item md={12}><FontAwesomeIcon icon="tags" />{" "}{this.props.tags}</Grid>
+            </Grid>
+          </Grid>{/* End of header area */}
+
+          <Grid item xs={12}>
+            <Card>
+              <CardContent>
+                <Typography variant={"h4"}>Description of <span style={{"word-wrap": "break-word"}}>{this.props.object.name}</span></Typography>
+                <ReactMarkdown source={this.props.object.description} />
+              </CardContent>
+            </Card>
+          </Grid>
+
+          <Grid item xs={12}>
+            <Card>
+              <CardContent>
+                  <CollapsibleDataTable title={"Dependencies"} data={dependenciesMap} rowrenderer={dep => (<DependencyDetail name={dep[0]} version={dep[1]} />)} />
+              </CardContent>
+            </Card>
+          </Grid>
+
+
+          <Grid item xs={12}>
+            <Card>
+              <CardContent>
+                  <CollapsibleDataTable title={"Parameters"} data={this.props.object.parameters} rowrenderer={m => (<ParameterDetail key={"fd_"+m.name} item={m} />)} maxLength={7} columns={parameterCols} />
+              </CardContent>
+            </Card>
+          </Grid>
+
+          <Grid item xs={12}>
+            <Card>
+              <CardContent>
+                <Typography variant={"h4"}>Runs ({this.props.object.runs})</Typography><br />
+                Run visualization not currently supported
+              </CardContent>
+            </Card>
+          </Grid>
+        </Grid>
       </React.Fragment>
     );
   }

--- a/server/src/client/app/src/pages/search/ItemDetail.js
+++ b/server/src/client/app/src/pages/search/ItemDetail.js
@@ -11,6 +11,10 @@ import { StudyItem } from "./Study.js";
 import { UserItem } from "./User.js";
 import { Chip } from "@material-ui/core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Table } from "@material-ui/core";
+import { TableRow } from "@material-ui/core";
+import { TableCell } from "@material-ui/core";
+import { TableBody } from "@material-ui/core";
 
 function fixUpperCase(str) {
   let o = "";
@@ -38,25 +42,22 @@ export class FeatureDetail extends React.Component {
         break;
     }
     return (
-      <div className="contentSection item">
-        <div className={"itemHead"}>
-          <FontAwesomeIcon icon={icon} />
-        </div>
-        <div className={"itemName"}>
-          {this.props.item.name}
-          {this.props.item.target ? (
-            <span className={"subtitle"}>(target)</span>
-          ) : (
-            ""
-          )}
-        </div>
-        <div className={"itemDetail-small"}>{this.props.item.type}</div>
-        <div className={"itemDetail-small"}>
-          {this.props.item.distinct} distinct values
-          <br />
-          {this.props.item.missing} missing attributes
-        </div>
-      </div>
+          <TableRow className="contentSection item">
+            <TableCell width={25}><FontAwesomeIcon icon={icon} /></TableCell>
+            <TableCell className={"itemName"}>
+              {this.props.item.name}
+              {this.props.item.target ? (
+                <span className={"subtitle"}> (target)</span>
+              ) : (
+                ""
+              )}
+            </TableCell>
+            <TableCell className={"itemDetail-small"}>{this.props.item.type}</TableCell>
+            <TableCell className={"itemDetail-small"}>
+              {this.props.item.distinct} distinct values<br />
+              {this.props.item.missing} missing attributes
+            </TableCell>
+          </TableRow>
     );
   }
 }
@@ -64,13 +65,11 @@ export class FeatureDetail extends React.Component {
 export class QualityDetail extends React.Component {
   render() {
     return (
-      <div className={"contentSection item"}>
-        <div className={"itemHead"}>
-          <span className={"fa fa-chart-bar"} />
-        </div>
-        <div className={"itemName"}>{fixUpperCase(this.props.item.name)}</div>
-        <div className={"itemDetail-small"}>{this.props.item.value}</div>
-      </div>
+      <TableRow>
+        <TableCell className={"itemHead"}><FontAwesomeIcon icon={"chart-bar"} /></TableCell>
+        <TableCell className={"itemName"}>{fixUpperCase(this.props.item.name)}</TableCell>
+        <TableCell className={"itemDetail-small"}>{this.props.item.value}</TableCell>
+      </TableRow>
     );
   }
 }

--- a/server/src/client/app/src/pages/search/ItemDetail.js
+++ b/server/src/client/app/src/pages/search/ItemDetail.js
@@ -11,7 +11,7 @@ import { StudyItem } from "./Study.js";
 import { UserItem } from "./User.js";
 import { Chip } from "@material-ui/core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Tooltip, TableRow, TableCell } from "@material-ui/core";
+import { Tooltip, TableRow, TableCell} from "@material-ui/core";
 import { withStyles } from '@material-ui/core/styles';
 
 function fixUpperCase(str) {
@@ -117,29 +117,23 @@ export class EvaluationDetail extends React.Component {
   render() {
     let classWiseEval = "";
     if (this.props.item.array_data != null) {
-      let classes = this.props.target_values.map(item => (<td key={"key_" + item}> {item} </td>));
       //same values result in same keys, counter is used to prevent it
       var ID = 0;
-      let values = this.props.item.array_data.map(item => (<td key={ID++}> {item} </td>));
-
       let rows = [];
-      classes.forEach((item, index) => {
-        var val = values[index];
-        rows.push(({item}));
+      this.props.target_values.forEach((item, i) => {
+        let val = this.props.item.array_data[i];
+        rows.push((<tr><td key={"key_"+item} style={{"width": "50%"}}>{item}</td><td key={ID++}>{val}</td></tr>));
       });
-
-
-/*
       classWiseEval = (<table width={"100%"}><tbody>
         {rows}
-      </tbody></table>);*/
+      </tbody></table>);
     }
 
     return (
       <TableRow>
-        <TableCell>{this.props.item.evaluation_measure}</TableCell>
-        <TableCell>{this.props.item.value}</TableCell>
-        <TableCell>{classWiseEval}</TableCell>
+        <TableCell style={{"width": "50%"}}>{this.props.item.evaluation_measure}</TableCell>
+        <TableCell style={{"width": "25%"}}>{this.props.item.value}</TableCell>
+        <TableCell style={{"width": "25%"}}>{classWiseEval}</TableCell>
       </TableRow>
     );
   }
@@ -148,7 +142,7 @@ export class FlowDetail extends React.Component {
   render() {
     return (
       <TableRow>
-        <TableCell><span style={{"wordWrap": "break-word"}}>{this.props.item.parameter}</span></TableCell>
+        <TableCell style={{"width": "50%"}}><span style={{"wordWrap": "break-word"}}>{this.props.item.parameter}</span></TableCell>
         <TableCell>{this.props.item.value}</TableCell>
       </TableRow>
     );

--- a/server/src/client/app/src/pages/search/ItemDetail.js
+++ b/server/src/client/app/src/pages/search/ItemDetail.js
@@ -11,10 +11,7 @@ import { StudyItem } from "./Study.js";
 import { UserItem } from "./User.js";
 import { Chip } from "@material-ui/core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Table } from "@material-ui/core";
-import { TableRow } from "@material-ui/core";
-import { TableCell } from "@material-ui/core";
-import { TableBody } from "@material-ui/core";
+import { TableRow, TableCell } from "@material-ui/core";
 
 function fixUpperCase(str) {
   let o = "";

--- a/server/src/client/app/src/pages/search/ItemDetail.js
+++ b/server/src/client/app/src/pages/search/ItemDetail.js
@@ -11,7 +11,8 @@ import { StudyItem } from "./Study.js";
 import { UserItem } from "./User.js";
 import { Chip } from "@material-ui/core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { TableRow, TableCell } from "@material-ui/core";
+import { Tooltip, TableRow, TableCell } from "@material-ui/core";
+import { withStyles } from '@material-ui/core/styles';
 
 function fixUpperCase(str) {
   let o = "";
@@ -59,6 +60,15 @@ export class FeatureDetail extends React.Component {
   }
 }
 
+export const LightTooltip = withStyles((theme) => ({
+  tooltip: {
+    backgroundColor: theme.palette.common.white,
+    color: 'rgba(0, 0, 0, 0.87)',
+    boxShadow: theme.shadows[1],
+    fontSize: 16,
+  },
+}))(Tooltip);
+
 export class QualityDetail extends React.Component {
   render() {
     return (
@@ -84,73 +94,63 @@ export class ParameterDetail extends React.Component {
   }
   render() {
     return (
-      <div className={"contentSection item"}>
-        <div className={"itemName"}>{fixUpperCase(this.props.item.name)}</div>
-        <div className={"itemDetail-small"}>
-          {this.props.item.default_value}
-        </div>
-      </div>
+      <TableRow>
+        <TableCell>{fixUpperCase(this.props.item.name)}</TableCell>
+        <TableCell>{this.props.item.description}</TableCell>
+        <TableCell>{this.props.item.data_type}</TableCell>
+        <TableCell>{this.props.item.default_value}</TableCell>
+      </TableRow>
+    );
+  }
+}
+export class DependencyDetail extends React.Component {
+  render() {
+    return (
+      <TableRow>
+        <TableCell>{this.props.name}</TableCell>
+        <TableCell>{this.props.version}</TableCell>
+      </TableRow>
     );
   }
 }
 export class EvaluationDetail extends React.Component {
   render() {
+    let classWiseEval = "";
     if (this.props.item.array_data != null) {
-      let classes = this.props.target_values.map(item => (
-        <td key={"key_" + item}> {item} </td>
-      ));
+      let classes = this.props.target_values.map(item => (<td key={"key_" + item}> {item} </td>));
       //same values result in same keys, counter is used to prevent it
       var ID = 0;
-      let values = this.props.item.array_data.map(item => (
-        <td key={ID++}> {item} </td>
-      ));
-      return (
-        <div className="evaluationContentSection">
-          <div className="leftContentSection">
-            {this.props.item.evaluation_measure}
-          </div>
-          <div className="rightContentSection">
-            <div className="smallContentSection">{this.props.item.value}</div>
-            <div className="smallContentSection">
-              <table>
-                <tbody>
-                  <tr>{classes}</tr>
-                  <tr>{values}</tr>
-                </tbody>
-              </table>
-            </div>
-            <div className="smallContentSection">
-              Cross-validation details (10-fold Crossvalidation)
-            </div>
-          </div>
-        </div>
-      );
-    } else {
-      return (
-        <div className="evaluationContentSection">
-          <div className="leftContentSection">
-            {this.props.item.evaluation_measure}
-          </div>
-          <div className="rightContentSection">
-            <div className="smallContentSection">{this.props.item.value}</div>
-            <div className="smallContentSection">
-              Cross-validation details (10-fold Crossvalidation)
-            </div>
-          </div>
-        </div>
-      );
+      let values = this.props.item.array_data.map(item => (<td key={ID++}> {item} </td>));
+
+      let rows = [];
+      classes.forEach((item, index) => {
+        var val = values[index];
+        rows.push(({item}));
+      });
+
+
+/*
+      classWiseEval = (<table width={"100%"}><tbody>
+        {rows}
+      </tbody></table>);*/
     }
+
+    return (
+      <TableRow>
+        <TableCell>{this.props.item.evaluation_measure}</TableCell>
+        <TableCell>{this.props.item.value}</TableCell>
+        <TableCell>{classWiseEval}</TableCell>
+      </TableRow>
+    );
   }
 }
 export class FlowDetail extends React.Component {
   render() {
     return (
-      <div className={"contentSection item"}>
-        <div className={"itemName"}>
-          {fixUpperCase(this.props.item.parameter)}
-        </div>
-        <div className={"itemDetail-small"}>{this.props.item.value}</div>
-      </div>
+      <TableRow>
+        <TableCell><span style={{"wordWrap": "break-word"}}>{this.props.item.parameter}</span></TableCell>
+        <TableCell>{this.props.item.value}</TableCell>
+      </TableRow>
     );
   }
 }

--- a/server/src/client/app/src/pages/search/MetaItems.js
+++ b/server/src/client/app/src/pages/search/MetaItems.js
@@ -1,0 +1,49 @@
+import React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+export class MetaTag extends React.Component {
+  render() {
+    let icon;
+    switch(this.props.type) {
+      case "format":
+        icon = "table";
+        break;
+      case "licence":
+        icon = "closed-captioning";
+        break;
+      case "task-type":
+        icon = "flag";
+        break;
+      case "dataset":
+        icon = "database";
+        break;
+      case "likes":
+        icon ="heart";
+        break;
+      case "downloads":
+        icon = "cloud";
+        break;
+      case "issues":
+        icon = "exclamation-triangle";
+        break;
+      case "downvotes":
+        icon = "thumbs-down";
+        break;
+      case "runs":
+        icon = "star";
+        break;
+      case "task":
+        icon = "trophy";
+        break;
+      default:
+        icon = "questionmark";
+        break;
+    }
+
+    return (
+      <span style={{"padding-right": "10px"}}>
+        <FontAwesomeIcon icon={icon} />{" "}{this.props.value}
+      </span>
+    )
+  }
+}

--- a/server/src/client/app/src/pages/search/MetaItems.js
+++ b/server/src/client/app/src/pages/search/MetaItems.js
@@ -1,9 +1,14 @@
 import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
+import {
+  Avatar,
+  Chip } from "@material-ui/core";
 export class MetaTag extends React.Component {
   render() {
     let icon;
+    let prefix = "";
+    let suffix = "";
     switch(this.props.type) {
       case "format":
         icon = "table";
@@ -22,6 +27,7 @@ export class MetaTag extends React.Component {
         break;
       case "downloads":
         icon = "cloud";
+        suffix = " downloads";
         break;
       case "issues":
         icon = "exclamation-triangle";
@@ -31,19 +37,39 @@ export class MetaTag extends React.Component {
         break;
       case "runs":
         icon = "star";
+        suffix = " runs";
         break;
       case "task":
         icon = "trophy";
+        prefix = "Task "
         break;
+      case "status":
+        icon = "eye";
+        break;
+      case "uploaded":
+        let uploadedDate = this.props.date !== undefined ? (<span><FontAwesomeIcon icon={"clock"} />{" "}{this.props.date}{" "}</span>) : "";
+        let uploadedBy = this.props.uploader !== undefined ? (<span>by <Chip size="small" variant="outlined" color="primary" avatar={<Avatar>{this.props.uploader.charAt(0)}</Avatar>} label={this.props.uploader} /></span>) : "";
+        return(<span style={{"paddingRight": "10px"}}>
+          <FontAwesomeIcon icon={"cloud-upload-alt"} />{" "}
+          uploaded{" "}
+          {uploadedDate}
+          {uploadedBy}
+        </span>);
       default:
         icon = "questionmark";
         break;
     }
 
     return (
-      <span style={{"padding-right": "10px"}}>
-        <FontAwesomeIcon icon={icon} />{" "}{this.props.value}
+      <span style={{"paddingRight": "10px"}}>
+        <FontAwesomeIcon icon={icon} />{" "}{prefix}{this.props.value}{suffix}
       </span>
     )
+  }
+}
+
+export class VisibilityChip extends React.Component {
+  render() {
+    return (<Chip variant="outlined" color="primary" size={"small"} label={this.props.visibility} style={{"margin-right": "10px"}} />);
   }
 }

--- a/server/src/client/app/src/pages/search/Run.js
+++ b/server/src/client/app/src/pages/search/Run.js
@@ -1,10 +1,24 @@
 import React from "react";
-import { SizeLimiter } from "./sizeLimiter.js";
 import { EvaluationDetail } from "./ItemDetail.js";
 import { FlowDetail } from "./ItemDetail.js";
+import {MetaTag} from "./MetaItems.js";
+
+import {
+  Card,
+  CardContent,
+  Typography,
+  Grid
+} from "@material-ui/core";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {CollapsibleDataTable} from "./sizeLimiter";
+import {QualityDetail} from "./ItemDetail";
 
 export class RunItem extends React.Component {
   render() {
+    let flowCols = ["Parameter", "Value"];
+    let evaluationMeasureCols = ["Evaluation Measure", "Value", ""];
+    console.log(this.props.object);
+
     //remove evaluations that do not have 'value' property from the retrieved api data
     var evaluations = [];
     if (this.props.object.evaluations) {
@@ -20,64 +34,62 @@ export class RunItem extends React.Component {
     var evaluationID = 0;
     return (
       <React.Fragment>
-        <h1 className={"sectionTitle"}>
-          <span className={"fa fa-trophy"} />
-          Run {this.props.object.run_id}
-        </h1>
-        <div className="subtitle"> </div>
-        <div className="dataStats">
-          <span>
-            <span className="fa fa-trophy" />
-            Task {this.props.object.run_task.task_id}{" "}
-            {this.props.object.run_task.name}{" "}
-          </span>
-          <span>
-            <span className="fa fa-database" />{" "}
-            {this.props.object.run_task.source_data.name}
-          </span>
-          <span>
-            <span className="fa fa-cloud-upload" />
-            uploaded {this.props.object.date} by {this.props.object.uploader}
-          </span>
-          <span>
-            <span className="fa fa-heart" />
-            {this.props.object.nr_of_likes} likes
-          </span>
-          <span>
-            <span className="fa fa-cloud" />
-            {this.props.object.nr_of_downloads} downloads
-          </span>
-          <span>
-            <span className="fa fa-exclamation-triangle" />
-            {this.props.object.nr_of_issues} issues
-          </span>
-          <span>
-            <span className="fa fa-thumbs-down" />
-            {this.props.object.nr_of_downvotes} downvotes
-          </span>
-          <span>
-            <span className="fa fa-tags" />
-            {this.props.tags}
-          </span>
-        </div>
-        <h1>Flow</h1>
-        <SizeLimiter maxLength={7}>
-          {this.props.object.run_flow.parameters.map(m => (
-            <FlowDetail key={parameterID++} item={m}></FlowDetail>
-          ))}
-        </SizeLimiter>
-        <h1> {this.props.object.evaluations.length} Evaluation measures</h1>
-        {evaluations.map(m => (
-          <EvaluationDetail
-            key={evaluationID++}
-            item={m}
-            target_values={this.props.object.run_task.target_values}
-          ></EvaluationDetail>
-        ))}
-        <h1>Tasks</h1>
-        <div className={"subtitle"}>
-          Task visualization not currently supported
-        </div>
+        <Grid container spacing={6}>
+          <Grid item xs={12}>
+            <Grid container style={{"padding": "25px 0"}}>
+              <Grid item md={12}>
+                <Typography variant="h1" style={{"marginBottom": "15px"}}><FontAwesomeIcon icon="trophy" />&nbsp;&nbsp;&nbsp;Run {this.props.object.run_id}</Typography>
+              </Grid>
+              <Grid item md={12}>
+                <MetaTag type={"task"} value={this.props.object.run_task.task_id} />
+                <MetaTag type={"dataset"} value={this.props.object.run_task.source_data.name} />
+                <MetaTag type={"status"} value={this.props.object.visibility} />
+                <MetaTag type={"uploaded"} date={this.props.object.date} uploader={this.props.object.uploader}/><br />
+
+                <MetaTag type={"likes"} value={this.props.object.nr_of_likes} />
+                <MetaTag type={"issues"} value={this.props.object.nr_of_issues} />
+                <MetaTag type={"downvotes"} value={this.props.object.nr_of_downvotes} />
+                <MetaTag type={"downloads"} value={this.props.object.nr_of_downloads} />
+              </Grid>
+            </Grid>
+
+            <Grid container>
+              <Grid item md={12}><FontAwesomeIcon icon="tags" />{" "}{this.props.tags}</Grid>
+            </Grid>
+
+          </Grid>
+
+          <Grid item xs={12}>
+            <Card>
+              <CardContent>
+                <Typography variant={"h4"}>Flow</Typography><br/>
+                <span style={{"wordWrap": "break-word"}}>{this.props.object.run_flow.name}</span>
+                <CollapsibleDataTable data={this.props.object.run_flow.parameters} rowrenderer={m => (<FlowDetail key={parameterID++} item={m}></FlowDetail>)} maxLength={7} columns={flowCols}/>
+              </CardContent>
+            </Card>
+          </Grid>
+
+
+          <Grid item xs={12}>
+            <Card>
+              <CardContent>
+                <CollapsibleDataTable title={"Evaluation Measures (" + this.props.object.run_task.estimation_procedure.name + ")"} data={evaluations} rowrenderer={m => (<EvaluationDetail key={evaluationID++} item={m} target_values={this.props.object.run_task.target_values} estimationProcedure={this.props.object.run_task.name} />)} maxLength={7} columns={evaluationMeasureCols} />
+              </CardContent>
+            </Card>
+          </Grid>
+
+          <Grid item xs={12}>
+            <Card>
+              <CardContent>
+                <Typography variant={"h4"}>Tasks</Typography>
+
+                <div className={"subtitle"}>
+                  Task visualization not currently supported
+                </div>
+              </CardContent>
+            </Card>
+          </Grid>
+        </Grid>
       </React.Fragment>
     );
   }

--- a/server/src/client/app/src/pages/search/Task.js
+++ b/server/src/client/app/src/pages/search/Task.js
@@ -17,34 +17,34 @@ import { Table, TableHead, TableBody, TableRow, TableCell } from "@material-ui/c
 export class TaskItem extends React.Component {
   render() {
     let taskDescription = [
-      { key: "Task ID", value: this.props.object.task_id},
-      { key: "Task Type", value: this.props.object.tasktype.name},
-      { key: "Source Data", value: this.props.object.source_data.name},
-      { key: "Target Feature", value: this.props.object.target_feature},
-      { key: "Estimation Procedure", value: this.props.object.estimation_procedure.name}
+      { name: "Task ID", value: this.props.object.task_id},
+      { name: "Task Type", value: this.props.object.tasktype.name},
+      { name: "Source Data", value: this.props.object.source_data.name},
+      { name: "Target Feature", value: this.props.object.target_feature},
+      { name: "Estimation Procedure", value: this.props.object.estimation_procedure.name}
     ];
-    console.log(this.props.object)
     return (
       <React.Fragment>
         <Grid container spacing={6}>
           <Grid item xs={12}>
             <Grid container style={{"padding": "25px 0"}}>
               <Grid item md={12}>
-                <Typography variant="h1" className={"sectionTitle"} style={{"margin-bottom": "15px"}}>
+                <Typography variant="h1" className={"sectionTitle"} style={{"marginBottom": "15px"}}>
                   <FontAwesomeIcon icon="trophy" />{" "}
                   {this.props.object.tasktype.name} on{" "}
                   {this.props.object.source_data.name}{" "}
                 </Typography>
               </Grid>
-              <Grid item md={12}>created <FontAwesomeIcon icon="clock" />{" "}{this.props.object.date}<br />
-                <MetaTag type={"task"} value={"Task " + this.props.object.task_id} />
+              <Grid item md={12}>
+                <MetaTag type={"task"} value={this.props.object.task_id} />
                 <MetaTag type={"task-type"} value={this.props.object.tasktype.name} />
-                <MetaTag type={"dataset"} value={"Task " + this.props.object.source_data.name} />
-                <MetaTag type={"runs"} value={this.props.object.runs + " runs submitted"} />
+                <MetaTag type={"dataset"} value={this.props.object.source_data.name} />
+                created <FontAwesomeIcon icon="clock" />{" "}{this.props.object.date}<br />
                 <MetaTag type={"likes"} value={this.props.object.nr_of_likes} />
-                <MetaTag type={"downloads"} value={this.props.object.nr_of_downloads} />
                 <MetaTag type={"issues"} value={this.props.object.nr_of_issues} />
                 <MetaTag type={"downvotes"} value={this.props.object.nr_of_downvotes} />
+                <MetaTag type={"downloads"} value={this.props.object.nr_of_downloads} />
+                <MetaTag type={"runs"} value={this.props.object.runs} />
                 {/*{" "}by{" "} <Grid item md={2} ><MetaDownvotes value={this.props.object.downvotes} /></Grid>*/}
               </Grid>
             </Grid>
@@ -59,12 +59,14 @@ export class TaskItem extends React.Component {
               <CardContent>
                 <Typography variant="h4" mb={6}>Details</Typography>
                 <Table>
+                  <TableBody>
                     {taskDescription.map(x => (
-                      <TableRow>
-                        <TableCell>{x.key}</TableCell>
+                      <TableRow  key={"row_"+x.name}>
+                        <TableCell>{x.name}</TableCell>
                         <TableCell>{x.value}</TableCell>
                       </TableRow>
-                      ))}
+                    ))}
+                  </TableBody>
                 </Table>
               </CardContent>
             </Card>

--- a/server/src/client/app/src/pages/search/Task.js
+++ b/server/src/client/app/src/pages/search/Task.js
@@ -1,52 +1,76 @@
 import React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  Chip,
+  Avatar,
+  Card,
+  CardContent,
+  Typography,
+  Grid
+} from "@material-ui/core";
+import {
+  MetaTag
+} from "./MetaItems"
+
+import { Table, TableHead, TableBody, TableRow, TableCell } from "@material-ui/core";
 
 export class TaskItem extends React.Component {
   render() {
+    let taskDescription = [
+      { key: "Task ID", value: this.props.object.task_id},
+      { key: "Task Type", value: this.props.object.tasktype.name},
+      { key: "Source Data", value: this.props.object.source_data.name},
+      { key: "Target Feature", value: this.props.object.target_feature},
+      { key: "Estimation Procedure", value: this.props.object.estimation_procedure.name}
+    ];
+    console.log(this.props.object)
     return (
       <React.Fragment>
-        <h1 className={"sectionTitle"}>
-          <span className={"fa fa-trophy fa-lg"} />
-          {this.props.object.tasktype.name} on{" "}
-          {this.props.object.source_data.name}{" "}
-        </h1>
-        <div className="subtitle">uploaded at {this.props.object.date}</div>
-        <div className="dataStats">
-          <span>
-            <span className="fa fa-trophy" /> Task {this.props.object.task_id}
-          </span>
-          <span>
-            <span className="fa fa-flag" />
-            {this.props.object.tasktype.name}
-          </span>
-          <span>
-            <span className="fa fa-database" />
-            {this.props.object.source_data.name}
-          </span>
-          <span>
-            <span className="fa fa-star" />
-            {this.props.object.runs} runs submitted
-          </span>
-          <span>
-            <span className="fa fa-heart" />
-            {this.props.object.nr_of_likes} likes
-          </span>
-          <span>
-            <span className="fa fa-cloud" />
-            {this.props.object.nr_of_downloads} downloads
-          </span>
-          <span>
-            <span className="fa fa-exclamation-triangle" />
-            {this.props.object.nr_of_issues} issues
-          </span>
-          <span>
-            <span className="fa fa-tag" />
-            {this.props.tags}
-          </span>
-        </div>
-        <h1>Task</h1>
-        <div className={"subtitle"}>
-          Task visualization not currently supported
-        </div>
+        <Grid container spacing={6}>
+          <Grid item xs={12}>
+            <Grid container style={{"padding": "25px 0"}}>
+              <Grid item md={12}>
+                <Typography variant="h1" className={"sectionTitle"} style={{"margin-bottom": "15px"}}>
+                  <FontAwesomeIcon icon="trophy" />{" "}
+                  {this.props.object.tasktype.name} on{" "}
+                  {this.props.object.source_data.name}{" "}
+                </Typography>
+              </Grid>
+              <Grid item md={12}>created <FontAwesomeIcon icon="clock" />{" "}{this.props.object.date}<br />
+                <MetaTag type={"task"} value={"Task " + this.props.object.task_id} />
+                <MetaTag type={"task-type"} value={this.props.object.tasktype.name} />
+                <MetaTag type={"dataset"} value={"Task " + this.props.object.source_data.name} />
+                <MetaTag type={"runs"} value={this.props.object.runs + " runs submitted"} />
+                <MetaTag type={"likes"} value={this.props.object.nr_of_likes} />
+                <MetaTag type={"downloads"} value={this.props.object.nr_of_downloads} />
+                <MetaTag type={"issues"} value={this.props.object.nr_of_issues} />
+                <MetaTag type={"downvotes"} value={this.props.object.nr_of_downvotes} />
+                {/*{" "}by{" "} <Grid item md={2} ><MetaDownvotes value={this.props.object.downvotes} /></Grid>*/}
+              </Grid>
+            </Grid>
+
+            <Grid container>
+              <Grid item md={12}><FontAwesomeIcon icon="tags" />{" "}{this.props.tags}</Grid>
+            </Grid>
+          </Grid>
+
+          <Grid item xs={12}>
+            <Card>
+              <CardContent>
+                <Typography variant="h4" mb={6}>Details</Typography>
+                <Table>
+                    {taskDescription.map(x => (
+                      <TableRow>
+                        <TableCell>{x.key}</TableCell>
+                        <TableCell>{x.value}</TableCell>
+                      </TableRow>
+                      ))}
+                </Table>
+              </CardContent>
+            </Card>
+          </Grid>
+
+        </Grid>
       </React.Fragment>
     );
   }

--- a/server/src/client/app/src/pages/search/sizeLimiter.js
+++ b/server/src/client/app/src/pages/search/sizeLimiter.js
@@ -43,6 +43,13 @@ export class SizeLimiter extends React.Component {
   }
 }
 
+export class StringLimiter extends React.Component {
+  render() {
+    let string = this.props.value.substring(0,this.props.maxLength);
+    return string + ((string.length < this.props.value.length) ? "..." : "");
+  }
+}
+
 export class CollapsibleDataTable extends React.Component {
   constructor() {
     super();

--- a/server/src/client/app/src/pages/search/sizeLimiter.js
+++ b/server/src/client/app/src/pages/search/sizeLimiter.js
@@ -1,4 +1,8 @@
 import React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Table, TableHead, TableBody, TableRow, TableCell } from "@material-ui/core";
+
+import { Typography } from "@material-ui/core";
 
 export class SizeLimiter extends React.Component {
   constructor() {
@@ -18,7 +22,7 @@ export class SizeLimiter extends React.Component {
               className={"expand"}
               onClick={() => this.setState({ expanded: false })}
             >
-              <span className={"fa fa-caret-up"} /> Show less
+              <FontAwesomeIcon icon="caret-up"/> Show less
             </div>
           </div>
         );
@@ -30,11 +34,62 @@ export class SizeLimiter extends React.Component {
               className={"expand"}
               onClick={() => this.setState({ expanded: true })}
             >
-              <span className={"fa fa-caret-down"} /> Show more
+              <FontAwesomeIcon icon="caret-down"/> Show more
             </div>
           </div>
         );
       }
     }
+  }
+}
+
+export class CollapsibleDataTable extends React.Component {
+  constructor() {
+    super();
+    this.state = { expanded: false };
+  }
+
+  render() {
+    let title = this.props.title !== undefined ? (<Typography variant="h4" mb={6}>{this.props.title}</Typography>) : "";
+    let subtitle = this.props.subtitle !== undefined ? (<div className={"subtitle"}>{this.props.subtitle}</div>) : "";
+
+    let tableHead = this.props.columns !== undefined ? (<TableHead>
+      <TableRow>
+        {this.props.columns.map(m => (<TableCell>{m}</TableCell>))}
+      </TableRow>
+    </TableHead>) : "";
+
+    let tableBody = "";
+    let collapsor = "";
+    let maxlen;
+
+    if(this.props.data !== undefined) {
+      maxlen = this.props.maxLength !== undefined ? Math.min(this.props.data.length, this.props.maxLength) : this.props.data.length;
+      tableBody = (<TableBody>
+        {this.props.data.slice(0, (this.state.expanded) ? this.props.data.length : maxlen).map(this.props.rowrenderer)}
+      </TableBody>);
+
+      if(this.props.maxLength < this.props.data.length) {
+        if(this.state.expanded) {
+          collapsor = (<div style={{"cursor": "pointer", "float": "right"}} onClick={() => this.setState({ expanded: false })}><FontAwesomeIcon icon="caret-up"/> Collapse</div>);
+        } else {
+          collapsor = (<div style={{"cursor": "pointer", "float": "right"}} onClick={() => this.setState({ expanded: true })}><FontAwesomeIcon icon="caret-down"/> Expand</div>);
+        }
+      }
+    }
+
+    return (
+      <div>
+        {collapsor}
+        {title}
+        {subtitle}
+        <Table>
+          {tableHead}
+          {tableBody}
+        </Table>
+        {this.state.expanded ? collapsor : ""}
+        <div style={{"clear": "right"}}></div>
+      </div>
+    )
   }
 }


### PR DESCRIPTION
This is a first draft for styling the details pages of dataset, flow, run, and task.

* Introduced CollapsibleDataTable component: a material-ui table that can be limited wrt. to the number of rows (can be expanded similar to the SizeLimiter component)
* Added the MetaItem component for keeping the meta data presentation of dataset, flow, run, and task consistent (icon and text)
* Styled the detail pages with the help of the aforementioned util components.