### PR TITLE
Match error message for login fail cases

### DIFF
--- a/server/user/views.py
+++ b/server/user/views.py
@@ -50,7 +50,7 @@ def login():
 
     if user is None:
         print("user does not exist")
-        return jsonify({"msg": "User does not exist"}), 200
+        return jsonify({"msg": "Wrong username or password"}), 200
 
     elif not user.check_password(jobj["password"]):
         print("Wrong password")


### PR DESCRIPTION
The error message when the user does not exist vs. when the password is wrong should be identical for security reasons.

Hotfix for #247, still does not address other possible angles of attack.

note: I did not build the website locally to test if this line actually achieves the change, but it's merely an assumption from the code.