### PR TITLE
Update regex e-mail

### DIFF
--- a/server/src/client/app/src/pages/auth/SignUp.js
+++ b/server/src/client/app/src/pages/auth/SignUp.js
@@ -43,7 +43,7 @@ function SignUp() {
       setError(true);
       setErrorMessage("Password too weak");
     } else if (
-      /[a-zA-Z0-9]+@(?:[a-zA-Z0-9]+\.)+[A-Za-z]+$/.test(
+      /[a-zA-Z0-9]+@(?:[a-zA-Z0-9-]+\.)+[A-Za-z]+$/.test(
         event.target.email.value
       ) !== true
     ) {


### PR DESCRIPTION
Allow a dash in the domain name, e.g., `foo@bar-bazz.com`. Might want to use some e-mail parsing library for this instead, but this at least fixes this oversight.