### PR TITLE
Update for docker compose

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -14,14 +14,14 @@ APP_SECRET_KEY=abcd
 JWT_SECRET_KEY=abcd
 TESTING=True
 
-URL_API=http://localhost:8002
+URL_API=http://localhost:8000/api/
 
 # REACT
 # React env variables are fixed when building the app.
 # React env variables need to be prefixed with "REACT_APP", otherwise the variables are ignored for
 # security reasons.
-REACT_APP_URL_SITE_BACKEND=http://localhost:5000/
-REACT_APP_URL_API=http://localhost:8002/
-REACT_APP_URL_ELASTICSEARCH=http://localhost:9200/
-REACT_APP_ELASTICSEARCH_VERSION_MAYOR=8
-REACT_APP_URL_MINIO=http://localhost:9000
+REACT_APP_URL_SITE_BACKEND=http://localhost:8000/
+REACT_APP_URL_API=http://localhost:8000/api/
+REACT_APP_URL_ELASTICSEARCH=http://localhost:8000/es/
+REACT_APP_ELASTICSEARCH_VERSION_MAYOR=6
+REACT_APP_URL_MINIO=http://localhost:8000/data/

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openml",
-  "version": "2.0.0",
+  "version": "2.0.20241011",
   "description": "OpenML - Open Source Machine Learning Platform",
   "author": "Joaquin Vanschoren",
   "private": false,

--- a/server/src/client/app/package.json
+++ b/server/src/client/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openml",
-  "version": "0.0.1",
+  "version": "2.0.20241011",
   "description": "OpenML Website",
   "author": "OpenML team",
   "private": true,


### PR DESCRIPTION
- Version bump of the OpenML packages, so that we can easily link code version with docker version. I noticed we have the version in two separated locations (in `/app` and `/server/src/client/app`). I guess it makes sense to use the same version for both?
- Update of the .env for the dev version, used in docker-compose.