### PR TITLE
Take into consideration the environment configuration

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -8,8 +8,8 @@ class Config(object):
     """
     Config object for flask app
     """
-
-    load_dotenv(".env")
+    environment = os.environ.get("environment", "")
+    load_dotenv(f".env{environment}")
     SQLALCHEMY_DATABASE_URI = os.environ.get("DATABASE_URI")
     #     'sqlite:///' + os.path.join(basedir, 'app.db')
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/server/extensions.py
+++ b/server/extensions.py
@@ -21,7 +21,8 @@ extension.py
 Declares extension for Flask App, connects with already existing database
 """
 # specifying engine according to existing db
-load_dotenv(".env")
+environment = os.environ.get("environment", "")
+load_dotenv(f".env{environment}")
 
 
 if not strtobool(os.environ.get("TESTING", "True")):


### PR DESCRIPTION
Following the convention from the dockerfile: 

https://github.com/openml/openml.org/blob/245d72cd03654be1caba0d1243a5d7feb18d1cf0/docker/Dockerfile#L6

I made modifications to the source code to similarly load a different `.env` file based on the `environment` defined.