### PR TITLE
Bugfix/349 overlapping home logos

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1,6 +1,6 @@
 # OpenML Website
 
-See https://docs.openml.org/Website/ for instructions on the current (React) app.
+See https://docs.openml.org/contributing/website/Website/ for instructions on the current (React) app.
 For the new (Next.js) app, see below.
 
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).

--- a/server/src/client/app/src/pages/cover/Cover.js
+++ b/server/src/client/app/src/pages/cover/Cover.js
@@ -13,7 +13,7 @@ import pythonIcon from "@iconify/icons-logos/python";
 import rLang from "@iconify/icons-logos/r-lang";
 import javaIcon from "@iconify/icons-logos/java";
 import cSharp from "@iconify/icons-logos/c-sharp";
-import pytorchIcon from "@iconify/icons-logos/pytorch";
+import pytorchIcon from "@iconify/icons-logos/pytorch-icon";
 import jupyterIcon from "@iconify/icons-logos/jupyter";
 
 import {


### PR DESCRIPTION
Fixes https://github.com/openml/openml.org/issues/349

Previous:
![image](https://github.com/user-attachments/assets/5899a432-f1f4-4992-9e8d-568e40405059)

Current:
<img width="816" alt="image" src="https://github.com/user-attachments/assets/14f5e4ba-3815-424d-ab77-1f16e5a22548" />

@PGijsbers, let me know if this version of the logo works or if the full logo with text is required.