### PR TITLE
Do not load pictures from search results for user lists

### DIFF
--- a/server/src/client/app/src/pages/search/SearchResultsPanel.js
+++ b/server/src/client/app/src/pages/search/SearchResultsPanel.js
@@ -226,7 +226,7 @@ class SearchElement extends React.Component {
           <SlimCardHeader
             avatar={
               <Avatar
-                src={this.props.image}
+                src="images/anonymousMan.png"
                 style={{
                   height: 50,
                   width: 50,


### PR DESCRIPTION
I want to avoid loading additional profile pages when navigating to a user.
Currently, because the search panel list is always constructed, even when it is not rendered, it loads images for the top profiles. This can lead to a lot of extra network calls and data being used.
Because clicking `<` back to list doesn't actually re-render the profiles, setting up lazy loading for image didn't seem to work, probably the image is considered "on screen".
I think this is okay since we don't have a normal way navigate to the user search panel, and hopefully this design can be reconsidered in the NextJS implementation.