### PR TITLE
Limit image file types and avoid encoding sensitive data in file path

### DIFF
--- a/server/src/client/app/src/pages/auth/Profile.js
+++ b/server/src/client/app/src/pages/auth/Profile.js
@@ -189,7 +189,7 @@ function Public() {
             <CenteredContent>
               <BigAvatar alt="User Image" id="dp" src={image} />
               <input
-                accept="image/*"
+                accept="image/png, image/jpeg, image/jpg, image/webp"
                 style={{ display: "none" }}
                 id="image"
                 multiple

--- a/server/src/client/app/src/pages/auth/Profile.js
+++ b/server/src/client/app/src/pages/auth/Profile.js
@@ -189,7 +189,7 @@ function Public() {
             <CenteredContent>
               <BigAvatar alt="User Image" id="dp" src={image} />
               <input
-                accept="image/png, image/jpeg, image/jpg, image/webp"
+                accept="image/jpeg, image/jpg"
                 style={{ display: "none" }}
                 id="image"
                 multiple

--- a/server/user/views.py
+++ b/server/user/views.py
@@ -1,5 +1,6 @@
 import os
 import secrets
+import uuid
 from distutils.util import strtobool
 from http import HTTPStatus
 from urllib.parse import parse_qs, urlparse
@@ -143,21 +144,34 @@ def image():
     if "file" not in request.files:
         return jsonify({"msg": "No image file supplied"}), HTTPStatus.BAD_REQUEST
     file_name = request.files["file"].filename
-    if '.' not in file_name or file_name.rsplit('.')[1].casefold() not in ALLOWED_IMAGE_EXTENSIONS:
+    if '.' not in file_name or (file_extension := file_name.rsplit('.')[1].casefold()) not in ALLOWED_IMAGE_EXTENSIONS:
         return jsonify({"msg": "Images of this file type are not supported"}), HTTPStatus.UNSUPPORTED_MEDIA_TYPE
 
     current_user = get_jwt_identity()
+    previous_image = None
     with Session() as session:
         user = session.query(User).filter_by(username=current_user).first()
+        previous_image = getattr(user, "image", None)
+
         f = request.files["file"]
-        Path("dev_data/" + str(user.username)).mkdir(parents=True, exist_ok=True)
-        f.save(
-            os.path.join("dev_data/" + str(user.username) + "/", secure_filename(f.filename))
-        )
-        path = "imgs/dev_data/" + str(user.username) + "/" + secure_filename(f.filename)
-        user.update_image_address(path)
+
+        file_directory = Path("dev_data/" + str(user.id))
+        file_directory.mkdir(parents=True, exist_ok=True)
+
+        new_file_name = secure_filename(f.filename)
+        if not new_file_name:
+            new_file_name = uuid.uuid4().hex + file_extension
+
+        new_file_path = file_directory / new_file_name
+
+        f.save(new_file_path)
+        user.update_image_address(new_file_path)
         session.merge(user)
         session.commit()
+
+    if previous_image and Path(previous_image).exists():
+        Path(previous_image).unlink()
+
     return jsonify({"msg": "User image changed"}), 200
 
 

--- a/server/user/views.py
+++ b/server/user/views.py
@@ -144,7 +144,7 @@ def image():
     if "file" not in request.files:
         return jsonify({"msg": "No image file supplied"}), HTTPStatus.BAD_REQUEST
     file_name = request.files["file"].filename
-    if '.' not in file_name or (file_extension := file_name.rsplit('.')[1].casefold()) not in ALLOWED_IMAGE_EXTENSIONS:
+    if '.' not in file_name or (file_extension := file_name.rsplit('.', 1)[1].casefold()) not in ALLOWED_IMAGE_EXTENSIONS:
         return jsonify({"msg": "Images of this file type are not supported"}), HTTPStatus.UNSUPPORTED_MEDIA_TYPE
 
     current_user = get_jwt_identity()

--- a/server/user/views.py
+++ b/server/user/views.py
@@ -33,7 +33,7 @@ CORS(user_blueprint)
 
 blocklist = set()
 
-ALLOWED_IMAGE_EXTENSIONS = ["webp", "png", "jpg", "jpeg"]
+ALLOWED_IMAGE_EXTENSIONS = ["jpg", "jpeg"]
 
 @jwt.token_in_blocklist_loader
 def check_if_token_in_blocklist(jwt_header, decrypted_token):


### PR DESCRIPTION
 - For profile pictures, allow only jpeg since that is the only format that actually works when retrieving the image.
 - Make sure that the path under which it is stored on the server does not contain sensitive data. In this case, the user name might have contained the e-mail of the user.

> [!WARNING]
> I have not been able to test these changes.