### PR TITLE
fix/copy: updated Honor Code and ToS link on Sign up page

### DIFF
--- a/server/src/client/app/src/pages/auth/SignUp.js
+++ b/server/src/client/app/src/pages/auth/SignUp.js
@@ -137,7 +137,7 @@ function SignUp() {
         <a
           target="_blank"
           rel="noopener noreferrer"
-          href="https://docs.openml.org/terms/"
+          href="https://docs.openml.org/intro/terms/"
         >
           Honor Code and Terms of Use
         </a>


### PR DESCRIPTION
@PGijsbers 

Noticed the current link was broken on the Sign Up page, so I updated it to the current Honor Code/ToS page.