### PR TITLE
feat: add robots.txt to prevent crawler traps

### DIFF
--- a/app/public/robots.txt
+++ b/app/public/robots.txt
@@ -1,0 +1,9 @@
+User-agent: *
+Disallow: /datasets?*
+Disallow: /tasks?*
+Disallow: /flows?*
+Disallow: /runs?*
+Allow: /datasets$
+Allow: /tasks$
+Allow: /flows$
+Allow: /runs$


### PR DESCRIPTION
This pull request introduces a new `robots.txt` file to control how search engines crawl and index certain pages of the application. The main change is to restrict search engine access to specific query-based URLs while allowing access to the main resource pages.

Search engine crawling restrictions:

* Added a new `robots.txt` file to disallow crawling of query parameter URLs for `datasets`, `tasks`, `flows`, and `runs` (e.g., `/datasets?*`), helping prevent indexing of filtered or search result pages.
* Allowed crawling of the main resource listing pages without query parameters (e.g., `/datasets), ensuring these pages remain indexable.


Fixes https://github.com/openml/openml.org/issues/335