### PR TITLE
fix: add redirect from /apis to /api for backward compatibility

### DIFF
--- a/app-next/next.config.ts
+++ b/app-next/next.config.ts
@@ -12,6 +12,13 @@ const nextConfig: NextConfig = {
       // SIMPLE PATH-BASED REDIRECTS (✅ Works in next.config.ts)
       // ========================================
 
+      // Legacy /apis route redirect to /api
+      {
+        source: "/apis",
+        destination: "/api",
+        permanent: true, // 301 redirect (preserves SEO and bookmarks)
+      },
+
       // Entity detail pages: /d/123 → /datasets/123 (no locale prefix for English)
       {
         source: "/d/:id",


### PR DESCRIPTION
## 🐛 Problem

The legacy `/apis` URL returns a "Not found" page while showing HTTP 200 status code. This creates confusion for users who have bookmarked the old URL or are following outdated documentation.

**Evidence:**
- `/apis` shows "Page Not Found :(" message
- Both `/apis` and `/api` return HTTP 200 OK status
- The actual route exists at `/api` (located at `src/app/[locale]/(learn)/api/page.tsx`)
- No `/apis` route exists in the new Next.js App Router structure

## ✅ Solution

Added a permanent (301) redirect from `/apis` to `/api` in `next.config.ts` to:
1. Maintain backward compatibility with old links and bookmarks
2. Properly return HTTP 301 status instead of showing 404 page with 200 status
3. Preserve SEO by using a permanent redirect
4. Guide users to the correct API documentation page

## 📝 Changes

- Added redirect rule in `app-next/next.config.ts`
- Placed at the beginning of the redirects array for clarity
- Used `permanent: true` for 301 redirect (better for SEO)

## 🧪 Testing

**Before:**
```
GET /apis → HTTP 200 + "Not found :(" page
```

**After:**
```
GET /apis → HTTP 301 → /api (API documentation page)
```

## 🔗 Related

- Part of the website refactoring to Next.js App Router
- Addresses legacy URL compatibility during migration
- Consistent with other redirect patterns already in `next.config.ts`
<img width="815" height="865" alt="Screenshot 2026-02-13 015436" src="https://github.com/user-attachments/assets/51b5233b-a28f-4053-b13c-799dfb4e8528" />
<img width="965" height="596" alt="Screenshot 2026-02-13 015520" src="https://github.com/user-attachments/assets/eb56b679-e105-461c-815d-a7e5b8dd785b" />
<img width="872" height="644" alt="Screenshot 2026-02-13 020917" src="https://github.com/user-attachments/assets/9b7b877f-6697-4058-8246-1bca3d9e0515" />
<img width="920" height="553" alt="Screenshot 2026-02-13 020939" src="https://github.com/user-attachments/assets/d1128863-76e8-4549-8535-37c06fb7b50e" />
