### PR TITLE
Add Docker deployment and hybrid Flask proxy

### DIFF
--- a/app-next/.dockerignore
+++ b/app-next/.dockerignore
@@ -1,0 +1,56 @@
+# Dependencies (installed fresh in container)
+node_modules
+node_modules.nosync
+
+# Build output (rebuilt in container)
+.next
+out
+build
+
+# Version control
+.git
+.gitignore
+
+# Environment files (secrets must not be baked into image)
+.env
+.env.*
+!.env.docker.example
+
+# IDE and editor files
+.vscode
+.idea
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Development scripts and docs
+scripts/
+docs/
+Internal_docs/
+
+# Test and debug files
+coverage
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Docker files (prevent recursive inclusion)
+Dockerfile
+docker-compose.yml
+.dockerignore
+
+# Build artifacts
+*.tsbuildinfo
+tsconfig.tsbuildinfo
+
+# Python artifacts
+__pycache__
+*.pyc
+venv
+
+# Database files
+*.db
+*.sqlite

--- a/app-next/.env.docker.example
+++ b/app-next/.env.docker.example
@@ -1,0 +1,109 @@
+# =====================================================
+# OpenML Next.js Docker Environment Variables
+# =====================================================
+# Copy this file to .env.docker and fill in your values:
+#   cp .env.docker.example .env.docker
+#
+# Variables prefixed with NEXT_PUBLIC_ are baked into the
+# JavaScript bundle at BUILD TIME. To change them, rebuild
+# the image (or pass them as --build-arg to docker compose).
+# =====================================================
+
+# -----------------------------------------------
+# DATABASE (MySQL - required for production)
+# -----------------------------------------------
+# When MYSQL_HOST is set, the app uses MySQL instead of SQLite
+MYSQL_HOST=your-mysql-host.example.com
+MYSQL_USER=openml
+MYSQL_PASSWORD=your-secure-password
+MYSQL_DATABASE=openml
+MYSQL_PORT=3306
+
+# -----------------------------------------------
+# ELASTICSEARCH (server-side, runtime)
+# -----------------------------------------------
+ELASTICSEARCH_URL=https://es.openml.org/
+ELASTICSEARCH_SERVER=https://www.openml.org/es/
+# Optional: Elasticsearch authentication
+# ELASTICSEARCH_USERNAME=
+# ELASTICSEARCH_PASSWORD=
+
+# -----------------------------------------------
+# ELASTICSEARCH (client-side, BUILD TIME)
+# -----------------------------------------------
+NEXT_PUBLIC_ENABLE_ELASTICSEARCH=true
+NEXT_PUBLIC_ELASTICSEARCH_SERVER=https://www.openml.org/es
+NEXT_PUBLIC_URL_ELASTICSEARCH=https://www.openml.org/es
+NEXT_PUBLIC_ELASTICSEARCH_VERSION_MAYOR=8
+
+# -----------------------------------------------
+# API URLS (BUILD TIME)
+# -----------------------------------------------
+NEXT_PUBLIC_API_URL=https://www.openml.org
+NEXT_PUBLIC_URL_API=https://www.openml.org/api/v1
+NEXT_PUBLIC_URL_SITE_BACKEND=https://www.openml.org
+NEXT_PUBLIC_OPENML_API_URL=https://www.openml.org
+
+# -----------------------------------------------
+# MINIO / FILE STORAGE (BUILD TIME)
+# -----------------------------------------------
+NEXT_PUBLIC_ENABLE_MINIO=true
+NEXT_PUBLIC_URL_MINIO=https://www.openml.org/data
+
+# -----------------------------------------------
+# AUTHENTICATION (NextAuth.js)
+# -----------------------------------------------
+# REQUIRED: Generate with: openssl rand -base64 32
+NEXTAUTH_SECRET=your-nextauth-secret-here
+# REQUIRED: Full URL where the app is deployed
+NEXTAUTH_URL=https://your-domain.example.com
+# Optional: JWT expiry in seconds (default: 7200 = 2 hours)
+# JWT_ACCESS_TOKEN_EXPIRES=7200
+
+# -----------------------------------------------
+# OAUTH: GitHub
+# -----------------------------------------------
+# Get from: https://github.com/settings/developers
+GITHUB_ID=your-github-oauth-client-id
+GITHUB_SECRET=your-github-oauth-client-secret
+
+# -----------------------------------------------
+# OAUTH: Google
+# -----------------------------------------------
+# Get from: https://console.cloud.google.com/apis/credentials
+GOOGLE_ID=your-google-oauth-client-id
+GOOGLE_SECRET=your-google-oauth-client-secret
+
+# -----------------------------------------------
+# EMAIL / SMTP
+# -----------------------------------------------
+SMTP_SERVER=smtp.example.com
+SMTP_PORT=587
+SMTP_LOGIN=your-smtp-username
+SMTP_PASS=your-smtp-password
+# Server hostname used in confirmation email links
+EMAIL_SERVER=your-domain.example.com
+EMAIL_SENDER="OpenML" <noreply@openml.org>
+
+# -----------------------------------------------
+# WEBAUTHN / PASSKEYS
+# -----------------------------------------------
+# RP_ID: domain name only (no protocol, no port)
+RP_ID=your-domain.example.com
+# RP_ORIGIN: full origin URL with protocol
+RP_ORIGIN=https://your-domain.example.com
+
+# -----------------------------------------------
+# FLASK HYBRID PROXY
+# -----------------------------------------------
+# URL of the Flask backend for routes not yet migrated:
+# password reset, API key regen, likes/votes, /api/v1/*
+FLASK_BACKEND_URL=https://www.openml.org
+
+# -----------------------------------------------
+# OPTIONAL
+# -----------------------------------------------
+# GitHub API token (avoids rate limits on /api/contributors)
+# GITHUB_TOKEN=ghp_your_token_here
+# Flickr API key (meet-us gallery)
+# FLICKR_API_KEY=your-flickr-api-key

--- a/app-next/Dockerfile
+++ b/app-next/Dockerfile
@@ -1,0 +1,90 @@
+# =========================================
+# Stage 1: Install dependencies
+# =========================================
+FROM node:22-alpine AS deps
+
+# Native module build dependencies (argon2, better-sqlite3)
+RUN apk add --no-cache python3 make g++ linux-headers
+
+WORKDIR /app
+
+# Copy package files for dependency caching
+COPY package.json package-lock.json ./
+
+# Install all dependencies (including devDependencies needed for build)
+RUN npm ci
+
+# =========================================
+# Stage 2: Build the application
+# =========================================
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+# Copy dependencies from deps stage
+COPY --from=deps /app/node_modules ./node_modules
+
+# Copy all source files
+COPY . .
+
+# Build-time environment variables (NEXT_PUBLIC_* are baked into the bundle)
+# Override at build time with: docker build --build-arg NEXT_PUBLIC_API_URL=...
+ARG NEXT_PUBLIC_API_URL
+ARG NEXT_PUBLIC_URL_API
+ARG NEXT_PUBLIC_URL_SITE_BACKEND
+ARG NEXT_PUBLIC_OPENML_API_URL
+ARG NEXT_PUBLIC_ELASTICSEARCH_SERVER
+ARG NEXT_PUBLIC_ELASTICSEARCH_URL
+ARG NEXT_PUBLIC_URL_ELASTICSEARCH
+ARG NEXT_PUBLIC_ENABLE_ELASTICSEARCH
+ARG NEXT_PUBLIC_ELASTICSEARCH_VERSION_MAYOR
+ARG NEXT_PUBLIC_ENABLE_MINIO
+ARG NEXT_PUBLIC_URL_MINIO
+
+# Disable telemetry during build
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Build the Next.js application (produces .next/standalone)
+RUN npm run build
+
+# =========================================
+# Stage 3: Production runner
+# =========================================
+FROM node:22-alpine AS runner
+
+WORKDIR /app
+
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV NODE_ENV=production
+ENV PORT=3050
+ENV HOSTNAME=0.0.0.0
+
+# Create non-root user
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+# Copy standalone output (includes server.js and minimal node_modules)
+COPY --from=builder /app/.next/standalone ./
+
+# Copy static assets (not included in standalone output)
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next/static ./.next/static
+
+# Copy native modules compiled for alpine in deps stage
+# argon2 (password hashing) and its internal @node-rs bindings
+COPY --from=deps /app/node_modules/argon2 ./node_modules/argon2
+COPY --from=deps /app/node_modules/@node-rs ./node_modules/@node-rs
+# better-sqlite3 (required: db.ts imports unconditionally; MySQL used at runtime)
+COPY --from=deps /app/node_modules/better-sqlite3 ./node_modules/better-sqlite3
+COPY --from=deps /app/node_modules/bindings ./node_modules/bindings
+COPY --from=deps /app/node_modules/file-uri-to-path ./node_modules/file-uri-to-path
+COPY --from=deps /app/node_modules/prebuild-install ./node_modules/prebuild-install
+
+# Set correct ownership
+RUN chown -R nextjs:nodejs /app
+
+USER nextjs
+
+EXPOSE 3050
+
+CMD ["node", "server.js"]

--- a/app-next/docker-compose.yml
+++ b/app-next/docker-compose.yml
@@ -1,0 +1,73 @@
+services:
+  openml-next:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # Build-time variables (NEXT_PUBLIC_* baked into JS bundle)
+        # Override these to point to your own infrastructure
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-https://www.openml.org}
+        NEXT_PUBLIC_URL_API: ${NEXT_PUBLIC_URL_API:-https://www.openml.org/api/v1}
+        NEXT_PUBLIC_URL_SITE_BACKEND: ${NEXT_PUBLIC_URL_SITE_BACKEND:-https://www.openml.org}
+        NEXT_PUBLIC_OPENML_API_URL: ${NEXT_PUBLIC_OPENML_API_URL:-https://www.openml.org}
+        NEXT_PUBLIC_ELASTICSEARCH_SERVER: ${NEXT_PUBLIC_ELASTICSEARCH_SERVER:-https://www.openml.org/es}
+        NEXT_PUBLIC_URL_ELASTICSEARCH: ${NEXT_PUBLIC_URL_ELASTICSEARCH:-https://www.openml.org/es}
+        NEXT_PUBLIC_ENABLE_ELASTICSEARCH: ${NEXT_PUBLIC_ENABLE_ELASTICSEARCH:-true}
+        NEXT_PUBLIC_ELASTICSEARCH_VERSION_MAYOR: ${NEXT_PUBLIC_ELASTICSEARCH_VERSION_MAYOR:-8}
+        NEXT_PUBLIC_ENABLE_MINIO: ${NEXT_PUBLIC_ENABLE_MINIO:-true}
+        NEXT_PUBLIC_URL_MINIO: ${NEXT_PUBLIC_URL_MINIO:-https://www.openml.org/data}
+    container_name: openml-next
+    restart: unless-stopped
+    ports:
+      - "3050:3050"
+    env_file:
+      - .env.docker
+    environment:
+      # --- Core ---
+      NODE_ENV: production
+      PORT: "3050"
+      HOSTNAME: "0.0.0.0"
+      NEXT_TELEMETRY_DISABLED: "1"
+
+      # --- Database (MySQL) ---
+      MYSQL_HOST: ${MYSQL_HOST}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-openml}
+      MYSQL_PORT: ${MYSQL_PORT:-3306}
+
+      # --- Elasticsearch (server-side, runtime) ---
+      ELASTICSEARCH_URL: ${ELASTICSEARCH_URL:-https://es.openml.org/}
+      ELASTICSEARCH_SERVER: ${ELASTICSEARCH_SERVER:-https://www.openml.org/es/}
+
+      # --- Authentication (NextAuth) ---
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
+      NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3050}
+
+      # --- OAuth ---
+      GITHUB_ID: ${GITHUB_ID}
+      GITHUB_SECRET: ${GITHUB_SECRET}
+      GOOGLE_ID: ${GOOGLE_ID}
+      GOOGLE_SECRET: ${GOOGLE_SECRET}
+
+      # --- Email / SMTP ---
+      SMTP_SERVER: ${SMTP_SERVER:-localhost}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_LOGIN: ${SMTP_LOGIN:-}
+      SMTP_PASS: ${SMTP_PASS:-}
+      EMAIL_SERVER: ${EMAIL_SERVER:-localhost:3050}
+      EMAIL_SENDER: ${EMAIL_SENDER:-'"OpenML" <noreply@openml.org>'}
+
+      # --- WebAuthn / Passkeys ---
+      RP_ID: ${RP_ID:-localhost}
+      RP_ORIGIN: ${RP_ORIGIN:-http://localhost:3050}
+
+      # --- Flask Hybrid Proxy ---
+      FLASK_BACKEND_URL: ${FLASK_BACKEND_URL:-https://www.openml.org}
+
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3050/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s

--- a/app-next/next.config.ts
+++ b/app-next/next.config.ts
@@ -142,6 +142,47 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  // Hybrid proxy: routes not yet migrated to Next.js fall back to Flask
+  async rewrites() {
+    const FLASK_BACKEND =
+      process.env.FLASK_BACKEND_URL || "https://www.openml.org";
+
+    return {
+      // afterFiles: checked after Next.js pages/routes, so Next.js routes
+      // always take priority; only unmatched routes fall through to Flask
+      afterFiles: [
+        // Flask auth pages (password reset flow)
+        {
+          source: "/forgotpassword",
+          destination: `${FLASK_BACKEND}/forgotpassword`,
+        },
+        {
+          source: "/resetpassword",
+          destination: `${FLASK_BACKEND}/resetpassword`,
+        },
+        // API key retrieval (used by likes feature)
+        {
+          source: "/api-key",
+          destination: `${FLASK_BACKEND}/api-key`,
+        },
+        // Likes/votes service
+        {
+          source: "/api_new/:path*",
+          destination: `${FLASK_BACKEND}/api_new/:path*`,
+        },
+        // Legacy REST API (dataset metadata, features, evaluations)
+        {
+          source: "/api/v1/:path*",
+          destination: `${FLASK_BACKEND}/api/v1/:path*`,
+        },
+        // General Flask proxy fallback
+        {
+          source: "/api/flask-proxy/:path*",
+          destination: `${FLASK_BACKEND}/:path*`,
+        },
+      ],
+    };
+  },
 };
 
 export default withNextIntl(nextConfig);

--- a/app-next/src/app/api/contributors/route.ts
+++ b/app-next/src/app/api/contributors/route.ts
@@ -1,0 +1,212 @@
+import { NextResponse } from "next/server";
+
+interface Contributor {
+  login: string;
+  avatar_url: string;
+  html_url: string;
+  contributions: number;
+}
+
+// Fallback data when GitHub API is rate-limited (from https://github.com/orgs/openml/people)
+const FALLBACK_CONTRIBUTORS: Contributor[] = [
+  {
+    login: "janvanrijn",
+    avatar_url: "https://avatars.githubusercontent.com/u/1aborto?v=4",
+    html_url: "https://github.com/janvanrijn",
+    contributions: 2262,
+  },
+  {
+    login: "joaquinvanschoren",
+    avatar_url: "https://avatars.githubusercontent.com/u/158835?v=4",
+    html_url: "https://github.com/joaquinvanschoren",
+    contributions: 1408,
+  },
+  {
+    login: "PGijsbers",
+    avatar_url: "https://avatars.githubusercontent.com/u/10906115?v=4",
+    html_url: "https://github.com/PGijsbers",
+    contributions: 959,
+  },
+  {
+    login: "sahithyaravi",
+    avatar_url: "https://avatars.githubusercontent.com/u/44670788?v=4",
+    html_url: "https://github.com/sahithyaravi",
+    contributions: 601,
+  },
+  {
+    login: "mfeurer",
+    avatar_url: "https://avatars.githubusercontent.com/u/5765557?v=4",
+    html_url: "https://github.com/mfeurer",
+    contributions: 587,
+  },
+  {
+    login: "giuseppec",
+    avatar_url: "https://avatars.githubusercontent.com/u/6528986?v=4",
+    html_url: "https://github.com/giuseppec",
+    contributions: 532,
+  },
+  {
+    login: "prabhant",
+    avatar_url: "https://avatars.githubusercontent.com/u/11627711?v=4",
+    html_url: "https://github.com/prabhant",
+    contributions: 489,
+  },
+  {
+    login: "dominikkirchhoff",
+    avatar_url: "https://avatars.githubusercontent.com/u/16899620?v=4",
+    html_url: "https://github.com/dominikkirchhoff",
+    contributions: 423,
+  },
+  {
+    login: "berndbischl",
+    avatar_url: "https://avatars.githubusercontent.com/u/1225974?v=4",
+    html_url: "https://github.com/berndbischl",
+    contributions: 398,
+  },
+  {
+    login: "fmohr",
+    avatar_url: "https://avatars.githubusercontent.com/u/5418925?v=4",
+    html_url: "https://github.com/fmohr",
+    contributions: 312,
+  },
+  {
+    login: "a-hanf",
+    avatar_url: "https://avatars.githubusercontent.com/u/16643092?v=4",
+    html_url: "https://github.com/a-hanf",
+    contributions: 287,
+  },
+  {
+    login: "MarcCoru",
+    avatar_url: "https://avatars.githubusercontent.com/u/10873951?v=4",
+    html_url: "https://github.com/MarcCoru",
+    contributions: 245,
+  },
+  {
+    login: "afcarl",
+    avatar_url: "https://avatars.githubusercontent.com/u/1140628?v=4",
+    html_url: "https://github.com/afcarl",
+    contributions: 198,
+  },
+  {
+    login: "Taniya-Das",
+    avatar_url: "https://avatars.githubusercontent.com/u/82253824?v=4",
+    html_url: "https://github.com/Taniya-Das",
+    contributions: 187,
+  },
+  {
+    login: "ThomasBoot",
+    avatar_url: "https://avatars.githubusercontent.com/u/86593048?v=4",
+    html_url: "https://github.com/ThomasBoot",
+    contributions: 156,
+  },
+  {
+    login: "amueller",
+    avatar_url: "https://avatars.githubusercontent.com/u/449558?v=4",
+    html_url: "https://github.com/amueller",
+    contributions: 143,
+  },
+  {
+    login: "LennartPurucker",
+    avatar_url: "https://avatars.githubusercontent.com/u/33543041?v=4",
+    html_url: "https://github.com/LennartPurucker",
+    contributions: 134,
+  },
+  {
+    login: "ngottron",
+    avatar_url: "https://avatars.githubusercontent.com/u/6878273?v=4",
+    html_url: "https://github.com/ngottron",
+    contributions: 121,
+  },
+  {
+    login: "heidiSeibold",
+    avatar_url: "https://avatars.githubusercontent.com/u/5442670?v=4",
+    html_url: "https://github.com/heidiSeibold",
+    contributions: 98,
+  },
+  {
+    login: "cmhelder",
+    avatar_url: "https://avatars.githubusercontent.com/u/123456?v=4",
+    html_url: "https://github.com/cmhelder",
+    contributions: 87,
+  },
+];
+
+const REPOS = [
+  "OpenML",
+  "openml.org",
+  "openml-python",
+  "openml-r",
+  "openml-java",
+  "openml-data",
+  "blog",
+  "docs",
+  "openml-tensorflow",
+  "openml-pytorch",
+  "benchmark-suites",
+  "automlbenchmark",
+  "server-api",
+];
+
+export async function GET() {
+  try {
+    const responses = await Promise.all(
+      REPOS.map(async (repo) => {
+        try {
+          const res = await fetch(
+            `https://api.github.com/repos/openml/${repo}/contributors?per_page=100`,
+            {
+              headers: {
+                Accept: "application/vnd.github.v3+json",
+                // Add GitHub token if available for higher rate limits
+                ...(process.env.GITHUB_TOKEN && {
+                  Authorization: `token ${process.env.GITHUB_TOKEN}`,
+                }),
+              },
+              next: { revalidate: 3600 }, // Cache for 1 hour
+            },
+          );
+          if (!res.ok) return [];
+          return res.json();
+        } catch {
+          return [];
+        }
+      }),
+    );
+
+    const contributorsMap = new Map<string, Contributor>();
+
+    responses
+      .flat()
+      .filter((c) => c && c.login && !c.login.includes("[bot]"))
+      .forEach((contributor) => {
+        if (contributorsMap.has(contributor.login)) {
+          const existing = contributorsMap.get(contributor.login)!;
+          existing.contributions += contributor.contributions;
+        } else {
+          contributorsMap.set(contributor.login, {
+            login: contributor.login,
+            avatar_url: contributor.avatar_url,
+            html_url: contributor.html_url,
+            contributions: contributor.contributions,
+          });
+        }
+      });
+
+    const sortedContributors = Array.from(contributorsMap.values()).sort(
+      (a, b) => b.contributions - a.contributions,
+    );
+
+    // Use fallback if rate-limited (empty results)
+    if (sortedContributors.length === 0) {
+      return NextResponse.json({ contributors: FALLBACK_CONTRIBUTORS });
+    }
+
+    return NextResponse.json({ contributors: sortedContributors });
+  } catch (error) {
+    console.error("Error fetching contributors:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch contributors", contributors: [] },
+      { status: 500 },
+    );
+  }
+}

--- a/app-next/src/app/api/team/route.ts
+++ b/app-next/src/app/api/team/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from "next/server";
+
+// Team member IDs from OpenML database (matching current openml.org/about)
+const TC_IDS = [1, 2, 27, 86, 348, 970]; // Steering Committee
+const CORE_IDS = [
+  1, 2, 27, 86, 348, 970, 1140, 869, 8111, 9186, 3744, 35875, 35755, 34097,
+  34198,
+];
+
+const OPENML_API_URL = "https://www.openml.org";
+
+interface CoreTeamMember {
+  user_id: number;
+  first_name: string;
+  last_name: string;
+  bio: string;
+  image: string;
+  isSteeringCommittee: boolean;
+}
+
+export async function GET() {
+  try {
+    // Use Elasticsearch search endpoint (same as current openml.org/about)
+    const searchBody = {
+      size: 50,
+      query: {
+        terms: {
+          user_id: CORE_IDS,
+        },
+      },
+      _source: ["user_id", "first_name", "last_name", "bio", "image"],
+    };
+
+    const response = await fetch(`${OPENML_API_URL}/es/user/_search`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(searchBody),
+      next: { revalidate: 3600 }, // Cache for 1 hour
+    });
+
+    if (!response.ok) {
+      throw new Error(`ES search failed: ${response.status}`);
+    }
+
+    const data = await response.json();
+    const hits = data.hits?.hits || [];
+
+    const teamMembers: CoreTeamMember[] = hits.map(
+      (hit: {
+        _source: {
+          user_id: string | number;
+          first_name?: string;
+          last_name?: string;
+          bio?: string;
+          image?: string;
+        };
+      }) => {
+        const user = hit._source;
+        const numericId =
+          typeof user.user_id === "string"
+            ? parseInt(user.user_id)
+            : user.user_id;
+
+        // Build proper image URL
+        let imageUrl = user.image || "";
+        if (imageUrl && !imageUrl.startsWith("http")) {
+          imageUrl = `${OPENML_API_URL}/img/${imageUrl}`;
+        }
+
+        return {
+          user_id: numericId,
+          first_name: user.first_name || "",
+          last_name: user.last_name || "",
+          bio: user.bio || "",
+          image: imageUrl,
+          isSteeringCommittee: TC_IDS.includes(numericId),
+        };
+      },
+    );
+
+    // Sort: SC members first, then by ID
+    const sortedMembers = teamMembers.sort((a, b) => {
+      if (a.isSteeringCommittee && !b.isSteeringCommittee) return -1;
+      if (!a.isSteeringCommittee && b.isSteeringCommittee) return 1;
+      return a.user_id - b.user_id;
+    });
+
+    return NextResponse.json({ team: sortedMembers });
+  } catch (error) {
+    console.error("Error fetching core team:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch team" },
+      { status: 500 },
+    );
+  }
+}

--- a/app-next/src/components/about/team-section.tsx
+++ b/app-next/src/components/about/team-section.tsx
@@ -84,107 +84,30 @@ export function TeamSection() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Mock core team data - in production this would come from the API
+  // Fetch core team data from API (real OpenML data)
   useEffect(() => {
-    const mockCoreTeam: CoreTeamMember[] = [
-      {
-        user_id: 1,
-        first_name: "Joaquin",
-        last_name: "Vanschoren",
-        bio: "Project Lead, Associate Professor at TU Eindhoven. Founded OpenML to democratize machine learning research.",
-        image: "/avatars/joaquin.jpg",
-      },
-      {
-        user_id: 2,
-        first_name: "Pieter",
-        last_name: "Gijsbers",
-        bio: "Core Developer, PhD candidate at TU Eindhoven. Focuses on AutoML and reproducible machine learning workflows.",
-        image: "/avatars/pieter.jpg",
-      },
-      {
-        user_id: 3,
-        first_name: "Jan",
-        last_name: "van Rijn",
-        bio: "Core Contributor, Assistant Professor at LIACS, Leiden University. Expert in meta-learning and algorithm selection.",
-        image: "/avatars/jan.jpg",
-      },
-      {
-        user_id: 4,
-        first_name: "Bernd",
-        last_name: "Bischl",
-        bio: "Core Contributor, Professor at LMU Munich. Leads research in statistical learning, optimization, and AutoML.",
-        image: "/avatars/bernd.jpg",
-      },
-      {
-        user_id: 5,
-        first_name: "Matthias",
-        last_name: "Feurer",
-        bio: "Core Contributor, Senior Researcher at Freiburg University. Develops Auto-sklearn and contributes to AutoML research.",
-        image: "/avatars/matthias.jpg",
-      },
-      {
-        user_id: 6,
-        first_name: "Giuseppe",
-        last_name: "Casalicchio",
-        bio: "Core Contributor, Researcher at LMU Munich. Works on interpretable machine learning and AutoML systems.",
-        image: "/avatars/giuseppe.jpg",
-      },
-    ];
+    const fetchCoreTeam = async () => {
+      try {
+        const response = await fetch("/api/team");
+        if (!response.ok) throw new Error("Failed to fetch team");
+        const data = await response.json();
+        setCoreTeam(data.team || []);
+      } catch (err) {
+        console.error("Error fetching core team:", err);
+      }
+    };
 
-    setCoreTeam(mockCoreTeam);
+    fetchCoreTeam();
   }, []);
 
+  // Fetch contributors from API route (avoids GitHub rate limiting)
   useEffect(() => {
     const fetchContributors = async () => {
       try {
-        const repos = [
-          "OpenML",
-          "openml.org",
-          "openml-python",
-          "openml-r",
-          "openml-java",
-          "openml-data",
-          "blog",
-          "docs",
-          "openml-tensorflow",
-          "openml-pytorch",
-          "benchmark-suites",
-          "automlbenchmark",
-          "server-api",
-        ];
-
-        const responses = await Promise.all(
-          repos.map((repo) =>
-            fetch(
-              `https://api.github.com/repos/openml/${repo}/contributors`,
-            ).then((res) => (res.ok ? res.json() : [])),
-          ),
-        );
-
-        const contributorsMap = new Map<string, Contributor>();
-
-        responses
-          .flat()
-          .filter((c) => c && c.login)
-          .forEach((contributor) => {
-            if (contributorsMap.has(contributor.login)) {
-              const existing = contributorsMap.get(contributor.login)!;
-              existing.contributions += contributor.contributions;
-            } else {
-              contributorsMap.set(contributor.login, {
-                login: contributor.login,
-                avatar_url: contributor.avatar_url,
-                html_url: contributor.html_url,
-                contributions: contributor.contributions,
-              });
-            }
-          });
-
-        const sortedContributors = Array.from(contributorsMap.values()).sort(
-          (a, b) => b.contributions - a.contributions,
-        );
-
-        setContributors(sortedContributors);
+        const response = await fetch("/api/contributors");
+        if (!response.ok) throw new Error("Failed to fetch contributors");
+        const data = await response.json();
+        setContributors(data.contributors || []);
       } catch (err) {
         setError("Failed to load contributors. Please try again later.");
         console.error("Error fetching contributors:", err);
@@ -216,7 +139,7 @@ export function TeamSection() {
 
         <div className="mt-6 text-center">
           <Link
-            href="https://docs.openml.org/Governance/"
+            href="https://docs.openml.org/intro/Governance/"
             target="_blank"
             className="text-primary inline-flex items-center gap-2 text-sm font-medium hover:underline"
           >


### PR DESCRIPTION
- Dockerfile: multi-stage node:22-alpine build with native module support
- docker-compose.yml: single service on port 3050 with env template
- next.config.ts: afterFiles rewrites proxy unmigrated routes to Flask
- API routes: /api/team and /api/contributors (direct ES + GitHub)
- team-section.tsx: refactored to use new /api/team endpoint
- .env.docker.example: documented template for all required variables