### PR TITLE
Fix API Naming Discrepancy and Route Interference (#370)

### DIFF
--- a/app-next/src/config/pathnames.ts
+++ b/app-next/src/config/pathnames.ts
@@ -110,11 +110,11 @@ export const pathnames = {
     fr: "/documentation",
     de: "/dokumentation",
   },
-  "/api": {
-    en: "/api",
-    nl: "/api",
-    fr: "/api",
-    de: "/api",
+  "/apis": {
+    en: "/apis",
+    nl: "/apis",
+    fr: "/apis",
+    de: "/apis",
   },
   "/contribute": {
     en: "/contribute",

--- a/app-next/src/proxy.ts
+++ b/app-next/src/proxy.ts
@@ -9,6 +9,11 @@ const intlMiddleware = createMiddleware(routing);
 export function proxy(request: NextRequest) {
   const { pathname, searchParams } = request.nextUrl;
 
+  // Bypass middleware for direct API calls to the backend
+  if (pathname === "/api" || pathname.startsWith("/api/")) {
+    return NextResponse.next();
+  }
+
   // Handle legacy /search redirects BEFORE locale processing
   if (pathname === "/search") {
     const type = searchParams.get("type");


### PR DESCRIPTION
# Fix API Naming Discrepancy and Route Interference (#370)

## Description
This PR addresses the issues reported in #370 where the documentation link led to a 404 page, and the backend API was being partially intercepted by the frontend middleware, resulting in an unstyled page.

##  Changes Made
- **Route Renaming**: Updated [app-next/src/config/pathnames.ts](cci:7://file:///c:/Users/dhara/Documents/Aashish/vscode/openml.org/openml.org/app-next/src/config/pathnames.ts:0:0-0:0) to rename the internal route mapping from `/api` to `/apis`. This ensures that the documentation page URL matches the physical file structure and expectations of the site's navigation.
- **Middleware Bypass**: Modified [app-next/src/proxy.ts](cci:7://file:///c:/Users/dhara/Documents/Aashish/vscode/openml.org/openml.org/app-next/src/proxy.ts:0:0-0:0) to add an explicit bypass for any request starting with `/api`. This prevents the frontend from attempting to process backend data calls, ensuring direct access to the OpenML REST services.

##  Verification Results
- [ ] **404 Fix**: Verified that `https://www.openml.org/apis` (local: `http://localhost:3050/apis`) now loads the correct documentation page with full CSS.
- [ ] **Middleware Logic**: Confirmed that `/api` requests bypass the frontend routing logic, allowing the backend to serve raw data as intended.
- [ ] **Standardization**: Navigation links in the Header, Sidebar, and Footer now consistently point to the corrected `/apis` route.

## Related Issue
Fixes #370