### PR TITLE
Use tag next-v... to trigger the github action

### DIFF
--- a/.github/workflows/release_docker_next.yaml
+++ b/.github/workflows/release_docker_next.yaml
@@ -2,6 +2,9 @@ name: release-docker-next
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - 'next-v*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/release_docker_next.yaml
+++ b/.github/workflows/release_docker_next.yaml
@@ -53,7 +53,7 @@ jobs:
           push: ${{ github.event_name == 'push' }}
 
       - name: Update repo description
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/next-v') }}
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/release_docker_next.yaml
+++ b/.github/workflows/release_docker_next.yaml
@@ -2,12 +2,15 @@ name: release-docker-next
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - 'next-v*'
+    inputs:
+      tag:
+        description: 'The tag of the published docker image. Format: v[Major].[Minor].[Patch] (do not forget the v).'
+        required: true
+        type: string
+
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -24,7 +27,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -33,27 +35,17 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Extract metadata (tags, labels) for Docker Hub
-        id: meta_dockerhub
-        uses: docker/metadata-action@v5
-        with:
-          images: "openml/frontend-next"
-          tags: |
-            type=semver,pattern={{raw}}
-
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v6
         with:
           context: app-next
           file: app-next/Dockerfile
-          tags: ${{ steps.meta_dockerhub.outputs.tags }}
-          labels: ${{ steps.meta_dockerhub.outputs.labels }}
+          tags: ${{ inputs.tags }}
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name == 'push' }}
+          push: true
 
       - name: Update repo description
-        if: ${{ startsWith(github.ref, 'refs/tags/next-v') }}
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
We need to have a way to trigger the docker release of the new frontend, and to state which version should be used as docker tag. 

[Edit]
New solution (thanks to Pieter): using github action parameter to set the tag.